### PR TITLE
Add support for debug log level

### DIFF
--- a/syngenta_digital_alc/common/logger.py
+++ b/syngenta_digital_alc/common/logger.py
@@ -13,15 +13,16 @@ class CommonLogger:
         self.__json.set_preferred_backend('simplejson')
         self.default_level = 3
         self.log_levels = {
+            'DEBUG': 0,
             'INFO': 1,
             'WARN': 2,
             'ERROR': 3
         }
 
-    def log(self,**kwargs):
-        if not os.getenv('RUN_MODE') == 'unittest' and os.getenv('STAGE') == 'local' and self.__should_log():
+    def log(self, **kwargs):
+        if not os.getenv('RUN_MODE') == 'unittest' and os.getenv('STAGE') == 'local' and self.__should_log(**kwargs):
             self.__log_local(**kwargs)
-        elif not os.getenv('RUN_MODE') == 'unittest' and self.__should_log():
+        elif not os.getenv('RUN_MODE') == 'unittest' and self.__should_log(**kwargs):
             self.__log(**kwargs)
 
     def __log_local(self, **kwargs):

--- a/tests/syngenta_digital_alc/common/test_logger.py
+++ b/tests/syngenta_digital_alc/common/test_logger.py
@@ -43,3 +43,10 @@ class LoggerTest(TestCase):
     @mock.patch.dict(os.environ, {'RUN_MODE': 'SEE-LOGS', 'STAGE': 'local', 'LOG_LEVEL': '1'})
     def test_logger_logs_see_info_numeric(self):
         logger.log(level='INFO', log={'INFO': 'see-numeric'}, trace=True)
+
+    @mock.patch.dict(os.environ, {'RUN_MODE': 'SEE-LOGS', 'STAGE': 'local', 'LOG_LEVEL': 'DEBUG'})
+    def test_logger_logs_see_debug(self):
+        jsonpickle_path = 'syngenta_digital_alc.common.logger.jsonpickle'
+        with mock.patch(jsonpickle_path) as jsonpickle_mock:
+            logger.log(level='DEBUG', log={'DEBUG': 'see'})
+            jsonpickle_mock.encode.assert_called_once()


### PR DESCRIPTION
We (`global-devops` team) would like to enhance our logging strategy in all our lambda functions. To achieve that, we would like to add logging instructions with different logging levels and control them via an environment variable. We noticed that the package supports the latter requirement. However, with regard to logging levels, we realized that it doesn't support `DEBUG`. While working on the required changes to provide such feature, we realized that the logic to check if the data should be logged in `CommonLogger.log()` was incorrect. Basically, the `**kwargs` were not being propagated to `CommonLogger.__should_log()` method. Thus, `CommonLogger.__get_log_level()` method was returning an incorrect value.

That said, this PR provides a set of changes to:
- Add support for `DEBUG` log level
- Fix an issue while checking if the `CommonLogger` should log the given data.

Signed-off-by: Isaias Ramirez Lopez <isaias.ramirez_lopez@syngenta.com>